### PR TITLE
Fix installation step numbering in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,56 +7,56 @@ TIGER is a Python module for directly accessing Exodus and Nemesis file data as 
     ```
     cd ~/projects/
     ```
-3. Clone the TIGER repo
+2. Clone the TIGER repo
     ```
     git clone https://github.com/chaitanyaBhave26/TIGER.git
     ```
 
 ### Option A - Conda installation (Recommended):
-3. If you don't already have Conda, install by following the instructions on the [Conda website](https://docs.conda.io/projects/conda/en/latest/user-guide/install/index.html). Alternatively, if you are installing TIGER on a HPC with prebuilt conda module, run
+1. If you don't already have Conda, install by following the instructions on the [Conda website](https://docs.conda.io/projects/conda/en/latest/user-guide/install/index.html). Alternatively, if you are installing TIGER on a HPC with prebuilt conda module, run
     ```
     module load conda
     ```
-4. Install the conda-build package
+2. Install the conda-build package
     ```
     conda activate base
     conda install conda-build
     ```
- 5. Create the TIGER environment and install dependencies
+3. Create the TIGER environment and install dependencies
     ```
     conda create --name tiger_env h5py netcdf4 matplotlib scipy numpy
     ```
-6. Build the TIGER package in development mode
+4. Build the TIGER package in development mode
     ```
     conda develop -n tiger_env ~/projects/TIGER 
     ```        
-7. Activate the TIGER environment. This step needs to be run whenever you want to use TIGER in a new terminal tab or window)
+5. Activate the TIGER environment. This step needs to be run whenever you want to use TIGER in a new terminal tab or window
     ```
     conda activate tiger_env
     ```   
-8. Optionally, you can install OpenCV if you want to perform Computer Vision operations on your exodus file outputs.
+6. Optionally, you can install OpenCV if you want to perform Computer Vision operations on your exodus file outputs.
     ```
     conda install -c menpo opencv
     ```
   
 ### Option B - Pip installation :
-3. If installing on a HPC, load python module
+1. If installing on a HPC, load python module
     ```
     module load python
     ```
-4. Install dependencies using PIP
+2. Install dependencies using PIP
     ```
     pip install matplotlib numpy scipy h5py netcdf4 opencv-python
     ```
-5. Change to TIGER directory
+3. Change to TIGER directory
     ```
     cd ~/projects/TIGER/
     ```
-6. Add TIGER directory to PYTHONPATH
+4. Add TIGER directory to PYTHONPATH
     ```
     export PYTHONPATH=$PYTHONPATH:~/projects/TIGER
     ```
-7. Importing modules from TIGER requires you to run step #6 every time you open the window. Alternatively you can copy that command into your bash profile (~/.bash_profile) using your choice of text editor. After copying the command, either restart the terminal window or run
+5. Importing modules from TIGER requires you to run step #4 every time you open the window. Alternatively you can copy that command into your bash profile (~/.bash_profile) using your choice of text editor. After copying the command, either restart the terminal window or run
   ```
   source ~/.bash_profile
   ```


### PR DESCRIPTION
## Summary
- Renumber installation steps for clarity
- Normalize numbering in Conda and Pip installation options and update cross-references

## Testing
- `pytest` *(fails: No module named 'matplotlib')*
- `pip install matplotlib` *(fails: Could not find a version that satisfies the requirement matplotlib)*

------
https://chatgpt.com/codex/tasks/task_e_68a1f883beec8321885b5e83741d6f5e