### PR TITLE
Handle floating point time lookup in MultiExodusReader

### DIFF
--- a/MultiExodusReader.py
+++ b/MultiExodusReader.py
@@ -26,9 +26,13 @@ class MultiExodusReader:
         x = er.x
         y = er.y
         z = er.z
-        idx = np.where(read_time == er.times)[0][0]
-        c = er.get_var_values(var_name,idx)
-        return (x,y,z,c)
+        # Use a tolerance when matching floating point time values
+        idx_arr = np.where(np.isclose(er.times, read_time))[0]
+        if idx_arr.size == 0:
+            raise ValueError(f"Time {read_time} not found in file {er.file_name}")
+        idx = idx_arr[0]
+        c = er.get_var_values(var_name, idx)
+        return (x, y, z, c)
 
     def get_data_at_time(self,var_name,read_time):
         X = []


### PR DESCRIPTION
## Summary
- Avoid direct floating point equality when locating times in multi-file datasets
- Raise an informative error if the requested time is absent

## Testing
- `python -m py_compile MultiExodusReader.py`


------
https://chatgpt.com/codex/tasks/task_e_68a1ee4ff55883219c21ac50d7789500