### PR TITLE
Add testing tools and optional MPI-based netCDF4 reading

### DIFF
--- a/ExodusReader.py
+++ b/ExodusReader.py
@@ -2,12 +2,25 @@ from netCDF4 import Dataset
 import numpy as np
 import os
 import re
+try:
+    from mpi4py import MPI
+except ImportError:  # pragma: no cover - mpi4py is optional
+    MPI = None
 
 class ExodusReader:
     def __init__(self,file_name):
         if os.path.exists(file_name):
             self.file_name = file_name
-            self.mesh = Dataset(self.file_name,'r') #,parallel=parallel_flag
+            if MPI is not None:
+                self.mesh = Dataset(
+                    self.file_name,
+                    "r",
+                    parallel=True,
+                    comm=MPI.COMM_WORLD,
+                    info=MPI.Info(),
+                )
+            else:
+                self.mesh = Dataset(self.file_name, "r")
             self.get_times()
             self.get_xyz()
             try:

--- a/Installation_Guide.txt
+++ b/Installation_Guide.txt
@@ -5,14 +5,14 @@ Installation instructions:
 Option A - Conda installation (Recommended):
 If you don't already have Conda, install it: https://docs.conda.io/projects/conda/en/latest/user-guide/install/index.html
   3. module load conda                              (Only needed on Hipergator)
-  4. conda create --name tiger_env h5py netcdf4 matplotlib scipy numpy
+  4. conda create --name tiger_env h5py netcdf4 matplotlib scipy numpy pytest cmcrameri mpi4py
   5. conda activate tiger_env                       (This step needs to be run whenever you want to use TIGER in a new terminal)
   6. conda develop ~/projects/TIGER                 (Or your TIGER directory)
   7. conda install -c menpo opencv
 
 Option B - Pip installation :
   3. module load python                             (Optional, needed on Hipergator )
-  4. pip install matplotlib numpy scipy h5py netcdf4 opencv-python
+  4. pip install matplotlib numpy scipy h5py netcdf4 opencv-python pytest cmcrameri mpi4py
   5. cd ~/projects/TIGER/
   6. export PYTHONPATH=$PYTHONPATH:~/projects/TIGER (Or whichever location you cloned TIGER to.)
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ TIGER is a Python module for directly accessing Exodus and Nemesis file data as 
     ```
 3. Create the TIGER environment and install dependencies
     ```
-    conda create --name tiger_env h5py netcdf4 matplotlib scipy numpy
+    conda create --name tiger_env h5py netcdf4 matplotlib scipy numpy pytest cmcrameri mpi4py
     ```
 4. Build the TIGER package in development mode
     ```
@@ -46,7 +46,7 @@ TIGER is a Python module for directly accessing Exodus and Nemesis file data as 
     ```
 2. Install dependencies using PIP
     ```
-    pip install matplotlib numpy scipy h5py netcdf4 opencv-python
+    pip install matplotlib numpy scipy h5py netcdf4 opencv-python pytest cmcrameri mpi4py
     ```
 3. Change to TIGER directory
     ```

--- a/tests/test_multi_exodus_reader.py
+++ b/tests/test_multi_exodus_reader.py
@@ -1,5 +1,5 @@
 import pytest
-np = pytest.importorskip("numpy")
+np = pytest.importorskip("numpy", exc_type=ImportError)
 import MultiExodusReader as mer
 
 


### PR DESCRIPTION
## Summary
- Document installing `pytest`, `cmcrameri`, and `mpi4py` for both conda and pip setups
- Optionally enable parallel netCDF4 reading via `mpi4py`
- Silence upcoming pytest deprecation warning for missing NumPy

## Testing
- ⚠️ `pip install numpy pytest cmcrameri -q` (ProxyError: Tunnel connection failed: 403 Forbidden)
- ⚠️ `pytest tests/test_multi_exodus_reader.py -q` (1 skipped: numpy not installed)


------
https://chatgpt.com/codex/tasks/task_e_68a20089adf08321a212d682262186be