### PR TITLE
Aggregate variable names across multi-file readers

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,13 @@
 
 TIGER is a Python module for directly accessing Exodus and Nemesis file data as numpy arrays. Examples demonstrate how to generate high quality figures using matplotlib and the TIGER interface.
 
+## Querying variables
+When reading multiple Exodus files, ``ExodusReader`` combines available variable
+names from each file. The resulting lists are exposed on the multi-file reader
+via ``nodal_var_names`` and ``elem_var_names``. These attributes show all nodal
+and elemental variables that may be requested with APIs such as
+``get_data_at_time``.
+
 ## Installation instructions:
 1. Go to your installation directory
     ```

--- a/tests/test_exodus_reader.py
+++ b/tests/test_exodus_reader.py
@@ -10,18 +10,28 @@ class DummyExodusReader:
         self.y = np.array([[0.0], [0.0]])
         self.z = np.array([[0.0], [0.0]])
         self.dim = 1
+        if "1" in file_name:
+            self.nodal_var_names = ["c_Cr", "a"]
+            self.elem_var_names = ["e1"]
+        else:
+            self.nodal_var_names = ["b", "c_Cr"]
+            self.elem_var_names = ["e2"]
 
     def get_var_values(self, var_name, idx):
         return np.array([idx, idx + 1])
 
 
 def test_get_data_at_time(monkeypatch):
-    monkeypatch.setattr(er.glob, "glob", lambda pattern: ["dummy.e"])
+    monkeypatch.setattr(er.glob, "glob", lambda pattern: ["f1.e", "f2.e"])
     monkeypatch.setattr(er.glob, "has_magic", lambda pattern: True)
     monkeypatch.setattr(er, "_SingleExodusReader", DummyExodusReader)
     mr = er.ExodusReader("dummy.e")
+    assert mr.nodal_var_names == ["a", "b", "c_Cr"]
+    assert mr.elem_var_names == ["e1", "e2"]
     x, y, z, c = mr.get_data_at_time("c_Cr", 1.0)
     assert x.shape == (2, 1)
     assert y.shape == (2, 1)
     assert z.shape == (2, 1)
     assert np.array_equal(c, np.array([1, 2]))
+    with pytest.raises(ValueError):
+        mr.get_data_at_time("missing", 1.0)


### PR DESCRIPTION
## Summary
- expose union of nodal and element variable names on multi-file Exodus readers
- validate requested variables against available names
- document how to query available variables

## Testing
- `pip install numpy` *(fails: Could not connect to proxy)*
- `pytest -q` *(fails: skipped: numpy is required)*

------
https://chatgpt.com/codex/tasks/task_e_68a21f808da08321bf9708d1bd9bf776