### PR TITLE
Handle empty glob in ExodusReader

### DIFF
--- a/ExodusReader.py
+++ b/ExodusReader.py
@@ -146,6 +146,8 @@ class _MultiExodusReader:
 
     def __init__(self, file_names: str) -> None:
         self.file_names = glob.glob(file_names)
+        if not self.file_names:
+            raise FileNotFoundError(file_names)
         global_times = set()
         file_times = []
         exodus_readers = []

--- a/tests/test_exodus_reader.py
+++ b/tests/test_exodus_reader.py
@@ -35,3 +35,11 @@ def test_get_data_at_time(monkeypatch):
     assert np.array_equal(c, np.array([1, 2]))
     with pytest.raises(ValueError):
         mr.get_data_at_time("missing", 1.0)
+
+
+def test_missing_files_raise_error(monkeypatch):
+    pattern = "missing*.e"
+    monkeypatch.setattr(er.glob, "glob", lambda pat: [])
+    monkeypatch.setattr(er.glob, "has_magic", lambda pat: True)
+    with pytest.raises(FileNotFoundError, match=pattern):
+        er.ExodusReader(pattern)


### PR DESCRIPTION
## Summary
- raise `FileNotFoundError` when multi-file pattern matches no files
- test that empty glob raises `FileNotFoundError`

## Testing
- `pytest -q` *(fails: missing numpy)*

------
https://chatgpt.com/codex/tasks/task_e_68a242838058832189cc83525bbafdbf