### PR TITLE
Simplify multi-file data aggregation and add shape test

### DIFF
--- a/ExodusReader.py
+++ b/ExodusReader.py
@@ -202,16 +202,10 @@ class _MultiExodusReader:
         for i, file_time in enumerate(self.file_times):
             if file_time[0] <= read_time and file_time[1] >= read_time:
                 x, y, z, c = self.get_data_from_file_idx(var_name, read_time, i)
-                try:
-                    X.append(x)
-                    Y.append(y)
-                    Z.append(z)
-                    C.append(c)
-                except Exception:  # pragma: no cover - fallback path
-                    X = x
-                    Y = y
-                    Z = z
-                    C = c
+                X.append(x)
+                Y.append(y)
+                Z.append(z)
+                C.append(c)
         X = np.vstack(X)
         Y = np.vstack(Y)
         Z = np.vstack(Z)

--- a/tests/test_exodus_reader.py
+++ b/tests/test_exodus_reader.py
@@ -43,3 +43,15 @@ def test_missing_files_raise_error(monkeypatch):
     monkeypatch.setattr(er.glob, "has_magic", lambda pat: True)
     with pytest.raises(FileNotFoundError, match=pattern):
         er.ExodusReader(pattern)
+
+
+def test_get_data_at_time_single_file(monkeypatch):
+    monkeypatch.setattr(er.glob, "glob", lambda pattern: ["f1.e"])
+    monkeypatch.setattr(er.glob, "has_magic", lambda pattern: True)
+    monkeypatch.setattr(er, "_SingleExodusReader", DummyExodusReader)
+    mr = er.ExodusReader("dummy.e")
+    x, y, z, c = mr.get_data_at_time("c_Cr", 1.0)
+    assert x.shape == (2, 1)
+    assert y.shape == (2, 1)
+    assert z.shape == (2, 1)
+    assert c.shape == (2,)


### PR DESCRIPTION
## Summary
- Remove fallback try/except and always append node and variable arrays before stacking in `get_data_at_time`
- Add unit test covering single-file aggregation to ensure output shapes remain correct

## Testing
- `pytest -q` *(fails: missing numpy dependency)*

------
https://chatgpt.com/codex/tasks/task_e_68a2452cd3bc8321b8f4e55b86f1dbfd